### PR TITLE
Update inertia_zz value for toes in gait3d_pelvis213_torque.osim

### DIFF
--- a/src/model/gait3d/osim_files/gait3d_pelvis213_torque.osim
+++ b/src/model/gait3d/osim_files/gait3d_pelvis213_torque.osim
@@ -1179,7 +1179,7 @@
 					<mass_center> 0.0346 0.006 -0.0175</mass_center>
 					<inertia_xx>0.0001</inertia_xx>
 					<inertia_yy>0.0002</inertia_yy>
-					<inertia_zz>0.001</inertia_zz>
+					<inertia_zz>0.0001</inertia_zz>
 					<inertia_xy>0</inertia_xy>
 					<inertia_xz>0</inertia_xz>
 					<inertia_yz>0</inertia_yz>
@@ -2043,7 +2043,7 @@
 					<mass_center> 0.0346 0.006 0.0175</mass_center>
 					<inertia_xx>0.0001</inertia_xx>
 					<inertia_yy>0.0002</inertia_yy>
-					<inertia_zz>0.001</inertia_zz>
+					<inertia_zz>0.0001</inertia_zz>
 					<inertia_xy>0</inertia_xy>
 					<inertia_xz>0</inertia_xz>
 					<inertia_yz>0</inertia_yz>


### PR DESCRIPTION
Fixed a typo originating from Hamner's Running model.
 - Restore the values from gait2392.osim
 - The values violated the triangle constraint for inertia