### PR TITLE
Model.getMetabolicCost_perNode: Edot^exponent was missing in continuous mode

### DIFF
--- a/src/model/@Model/getMetabolicRate_pernode.m
+++ b/src/model/@Model/getMetabolicRate_pernode.m
@@ -136,4 +136,7 @@ else
     dEdotdu(obj.extractControl('u'))  = exponent*Edot.^(exponent-1).*dEdot(:, nDofs*2+4);
 
 end
+
+Edot = Edot.^exponent;
+
 end


### PR DESCRIPTION
Fixes #21 